### PR TITLE
Add responsive Chinese news hotlist single page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>中国新闻热搜榜 - 今日热榜</title>
+  <meta name="description" content="中国新闻热搜榜，实时了解今日最热新闻、热点词云与分类筛选，以及投稿纠错入口。" />
+  <meta name="keywords" content="中国, 新闻, 热搜, 热榜, 今日新闻, 热点词云" />
+  <meta property="og:title" content="中国新闻热搜榜" />
+  <meta property="og:description" content="查看中国新闻今日热榜，掌握即时热点，欢迎投稿与纠错。" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://example.com/news-hotlist" />
+  <meta property="og:image" content="https://via.placeholder.com/1200x630" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header" role="banner">
+    <div class="logo" aria-label="中国新闻热搜榜 Logo">中国新闻热搜榜</div>
+    <form class="search-form" role="search" aria-label="站内搜索">
+      <label for="searchInput" class="sr-only">搜索热点</label>
+      <input type="search" id="searchInput" placeholder="搜索热点新闻" aria-label="搜索热点新闻" />
+      <button type="submit" aria-label="执行搜索">搜索</button>
+    </form>
+    <div class="header-actions">
+      <button id="themeToggle" type="button" aria-pressed="false" aria-label="切换深浅色模式">🌗</button>
+      <button id="openForm" type="button" class="primary-btn" aria-haspopup="dialog" aria-controls="submissionModal">投稿 / 纠错</button>
+    </div>
+  </header>
+
+  <main class="layout" role="main">
+    <section class="hotlist" aria-labelledby="hotlistTitle">
+      <div class="section-header">
+        <h1 id="hotlistTitle">今日热榜</h1>
+        <div class="controls" aria-label="排序与分页控制">
+          <label for="sortSelect">排序：</label>
+          <select id="sortSelect" aria-label="热榜排序">
+            <option value="heat">按热度</option>
+            <option value="time">按时间</option>
+          </select>
+          <div class="pagination" role="navigation" aria-label="分页">
+            <button id="prevPage" type="button" aria-label="上一页">上一页</button>
+            <span id="paginationInfo" aria-live="polite"></span>
+            <button id="nextPage" type="button" aria-label="下一页">下一页</button>
+          </div>
+        </div>
+      </div>
+      <ul class="hotlist-items" id="hotlistItems" aria-live="polite"></ul>
+    </section>
+
+    <aside class="sidebar" aria-labelledby="sidebarTitle">
+      <h2 id="sidebarTitle">热点词云 / 分类筛选</h2>
+      <div class="word-cloud" role="list">
+        <span role="listitem" class="tag tag-large">科技</span>
+        <span role="listitem" class="tag tag-medium">经济</span>
+        <span role="listitem" class="tag tag-small">教育</span>
+        <span role="listitem" class="tag tag-medium">社会</span>
+        <span role="listitem" class="tag tag-large">民生</span>
+        <span role="listitem" class="tag tag-small">文娱</span>
+        <span role="listitem" class="tag tag-medium">体育</span>
+        <span role="listitem" class="tag tag-small">国际</span>
+        <span role="listitem" class="tag tag-medium">健康</span>
+      </div>
+      <div class="filters" aria-label="分类筛选">
+        <button type="button" class="filter-btn" data-filter="全部">全部</button>
+        <button type="button" class="filter-btn" data-filter="科技">科技</button>
+        <button type="button" class="filter-btn" data-filter="经济">经济</button>
+        <button type="button" class="filter-btn" data-filter="社会">社会</button>
+        <button type="button" class="filter-btn" data-filter="文娱">文娱</button>
+      </div>
+    </aside>
+  </main>
+
+  <button id="backToTop" class="back-to-top" aria-label="返回顶部">⤴</button>
+
+  <footer class="site-footer" role="contentinfo">
+    <p>© 2024 中国新闻热搜榜 | 版权所有</p>
+    <p>ICP备案号：京ICP备20240001号-1 | 举报邮箱：report@example.com</p>
+  </footer>
+
+  <div id="submissionModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" aria-hidden="true">
+    <div class="modal-content" role="document">
+      <button type="button" class="modal-close" aria-label="关闭投稿表单">×</button>
+      <h2 id="modalTitle">投稿 / 纠错</h2>
+      <form id="submissionForm" novalidate>
+        <div class="form-group">
+          <label for="newsTitle">标题 *</label>
+          <input type="text" id="newsTitle" name="newsTitle" required aria-required="true" />
+          <span class="error" id="titleError" role="alert"></span>
+        </div>
+        <div class="form-group">
+          <label for="newsLink">链接 *</label>
+          <input type="url" id="newsLink" name="newsLink" required aria-required="true" placeholder="https://example.com" />
+          <span class="error" id="linkError" role="alert"></span>
+        </div>
+        <div class="form-group">
+          <label for="newsSource">来源 *</label>
+          <input type="text" id="newsSource" name="newsSource" required aria-required="true" />
+          <span class="error" id="sourceError" role="alert"></span>
+        </div>
+        <div class="form-group">
+          <label for="newsSummary">摘要 *</label>
+          <textarea id="newsSummary" name="newsSummary" required aria-required="true" rows="3"></textarea>
+          <span class="error" id="summaryError" role="alert"></span>
+        </div>
+        <div class="form-group">
+          <label for="email">邮箱 *</label>
+          <input type="email" id="email" name="email" required aria-required="true" placeholder="you@example.com" />
+          <span class="error" id="emailError" role="alert"></span>
+        </div>
+        <div class="form-group">
+          <label for="imageUpload">上传图片</label>
+          <input type="file" id="imageUpload" name="imageUpload" accept="image/*" />
+        </div>
+        <div class="form-actions">
+          <button type="submit" class="primary-btn">提交</button>
+          <button type="reset">重置</button>
+        </div>
+        <p class="form-success" id="formSuccess" role="status" aria-live="polite" hidden>提交成功，感谢您的贡献！</p>
+      </form>
+    </div>
+  </div>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,333 @@
+const newsData = [
+  {
+    id: 1,
+    title: "国产大飞机完成新航线首飞",
+    source: "新华网",
+    heat: 987654,
+    timestamp: "2024-05-12T09:30:00",
+    summary: "C919国产大飞机完成上海至北京定期航线首飞，标志着国产民航运输能力再获突破。",
+    category: "科技",
+    image: "https://via.placeholder.com/400x240?text=News+1"
+  },
+  {
+    id: 2,
+    title: "多省出台稳就业新政支持高校毕业生",
+    source: "央视新闻",
+    heat: 865432,
+    timestamp: "2024-05-12T08:45:00",
+    summary: "围绕高校毕业生就业，多省发布系列扶持政策，涵盖补贴、培训、岗位拓展等措施。",
+    category: "经济",
+    image: "https://via.placeholder.com/400x240?text=News+2"
+  },
+  {
+    id: 3,
+    title: "全国首个无人驾驶公交线路投入运营",
+    source: "人民网",
+    heat: 812340,
+    timestamp: "2024-05-12T07:50:00",
+    summary: "深圳上线全国首个全场景无人驾驶公交线路，日均运送乘客突破5000人次。",
+    category: "科技",
+    image: "https://via.placeholder.com/400x240?text=News+3"
+  },
+  {
+    id: 4,
+    title: "中国女排夺得世界联赛首站冠军",
+    source: "新华社",
+    heat: 689123,
+    timestamp: "2024-05-11T22:10:00",
+    summary: "中国女排在世界女排联赛首站比赛中击败劲旅夺冠，主攻手斩获全场MVP。",
+    category: "体育",
+    image: "https://via.placeholder.com/400x240?text=News+4"
+  },
+  {
+    id: 5,
+    title: "长三角一体化示范区发布数字政务合作框架",
+    source: "解放日报",
+    heat: 534890,
+    timestamp: "2024-05-11T18:20:00",
+    summary: "示范区三地联合推出数字政务合作框架，实现政务服务事项跨域通办。",
+    category: "社会",
+    image: "https://via.placeholder.com/400x240?text=News+5"
+  },
+  {
+    id: 6,
+    title: "新冠疫苗加强针覆盖率持续提升",
+    source: "健康时报",
+    heat: 498765,
+    timestamp: "2024-05-11T16:05:00",
+    summary: "国家卫健委发布数据显示，全国新冠疫苗加强针接种覆盖率持续提升，重点人群完成率达92%。",
+    category: "健康",
+    image: "https://via.placeholder.com/400x240?text=News+6"
+  },
+  {
+    id: 7,
+    title: "世界智能大会聚焦人工智能安全治理",
+    source: "科技日报",
+    heat: 478990,
+    timestamp: "2024-05-11T13:40:00",
+    summary: "与会专家呼吁加强人工智能安全治理，推动行业标准制定与国际合作。",
+    category: "科技",
+    image: "https://via.placeholder.com/400x240?text=News+7"
+  },
+  {
+    id: 8,
+    title: "大型史诗话剧《长城》首演收获好评",
+    source: "中国文化报",
+    heat: 365432,
+    timestamp: "2024-05-10T19:30:00",
+    summary: "融合多媒体舞台技术的史诗话剧《长城》在北京首演，以创新视角讲述长城故事。",
+    category: "文娱",
+    image: "https://via.placeholder.com/400x240?text=News+8"
+  }
+];
+
+const state = {
+  sortBy: "heat",
+  currentPage: 1,
+  itemsPerPage: 4,
+  filter: "全部",
+  searchKeyword: ""
+};
+
+const hotlistItems = document.getElementById("hotlistItems");
+const sortSelect = document.getElementById("sortSelect");
+const paginationInfo = document.getElementById("paginationInfo");
+const prevPageBtn = document.getElementById("prevPage");
+const nextPageBtn = document.getElementById("nextPage");
+const filterButtons = document.querySelectorAll(".filter-btn");
+const searchForm = document.querySelector(".search-form");
+const searchInput = document.getElementById("searchInput");
+const themeToggle = document.getElementById("themeToggle");
+const backToTopBtn = document.getElementById("backToTop");
+const openFormBtn = document.getElementById("openForm");
+const modal = document.getElementById("submissionModal");
+const closeModalBtn = modal.querySelector(".modal-close");
+const submissionForm = document.getElementById("submissionForm");
+const successMessage = document.getElementById("formSuccess");
+
+function sortData(data) {
+  const sorted = [...data];
+  if (state.sortBy === "heat") {
+    sorted.sort((a, b) => b.heat - a.heat);
+  } else if (state.sortBy === "time") {
+    sorted.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+  }
+  return sorted;
+}
+
+function filterData(data) {
+  return data.filter(item => {
+    const matchFilter = state.filter === "全部" || item.category === state.filter;
+    const matchKeyword = item.title.includes(state.searchKeyword.trim());
+    return matchFilter && matchKeyword;
+  });
+}
+
+function renderHotlist() {
+  const sorted = sortData(newsData);
+  const filtered = filterData(sorted);
+  const totalItems = filtered.length;
+  const totalPages = Math.ceil(totalItems / state.itemsPerPage) || 1;
+
+  if (state.currentPage > totalPages) {
+    state.currentPage = totalPages;
+  }
+
+  const startIndex = (state.currentPage - 1) * state.itemsPerPage;
+  const paginatedItems = filtered.slice(startIndex, startIndex + state.itemsPerPage);
+
+  hotlistItems.innerHTML = "";
+
+  paginatedItems.forEach((item, index) => {
+    const globalIndex = sorted.findIndex(news => news.id === item.id);
+    const rank = globalIndex + 1;
+    const icon = rank === 1 ? "🏆" : rank <= 3 ? "🔥" : "";
+    const listItem = document.createElement("li");
+    listItem.className = "hot-card";
+    listItem.innerHTML = `
+      <div class="hot-card-header">
+        <span class="hot-card-rank" aria-label="排名">${rank.toString().padStart(2, "0")}</span>
+        ${icon ? `<span class="hot-card-icon" aria-hidden="true">${icon}</span>` : ""}
+        <div class="hot-card-meta">
+          <span aria-label="来源">${item.source}</span>
+          <span aria-label="热度">热度 ${item.heat.toLocaleString()}</span>
+          <span aria-label="时间">${formatTime(item.timestamp)}</span>
+        </div>
+      </div>
+      <div class="hot-card-image">
+        <img src="${item.image}" alt="${item.title} 缩略图" loading="lazy" />
+      </div>
+      <div class="hot-card-content">
+        <h3>${item.title}</h3>
+        <p>${item.summary}</p>
+      </div>
+    `;
+    listItem.setAttribute("data-category", item.category);
+    hotlistItems.appendChild(listItem);
+  });
+
+  paginationInfo.textContent = `${state.currentPage} / ${totalPages}`;
+  prevPageBtn.disabled = state.currentPage === 1;
+  nextPageBtn.disabled = state.currentPage === totalPages;
+}
+
+function formatTime(timestamp) {
+  const date = new Date(timestamp);
+  return `${date.getMonth() + 1}月${date.getDate()}日 ${date.getHours().toString().padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}`;
+}
+
+sortSelect.addEventListener("change", event => {
+  state.sortBy = event.target.value;
+  state.currentPage = 1;
+  renderHotlist();
+});
+
+prevPageBtn.addEventListener("click", () => {
+  if (state.currentPage > 1) {
+    state.currentPage -= 1;
+    renderHotlist();
+  }
+});
+
+nextPageBtn.addEventListener("click", () => {
+  state.currentPage += 1;
+  renderHotlist();
+});
+
+filterButtons.forEach(button => {
+  button.addEventListener("click", () => {
+    filterButtons.forEach(btn => btn.classList.remove("active"));
+    button.classList.add("active");
+    state.filter = button.dataset.filter;
+    state.currentPage = 1;
+    renderHotlist();
+  });
+});
+
+searchForm.addEventListener("submit", event => {
+  event.preventDefault();
+  state.searchKeyword = searchInput.value;
+  state.currentPage = 1;
+  renderHotlist();
+});
+
+const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+const savedTheme = localStorage.getItem("theme");
+if (savedTheme === "dark" || (!savedTheme && prefersDark)) {
+  document.body.classList.add("dark-theme");
+  themeToggle.setAttribute("aria-pressed", "true");
+}
+
+themeToggle.addEventListener("click", () => {
+  document.body.classList.toggle("dark-theme");
+  const isDark = document.body.classList.contains("dark-theme");
+  themeToggle.setAttribute("aria-pressed", String(isDark));
+  localStorage.setItem("theme", isDark ? "dark" : "light");
+});
+
+window.addEventListener("scroll", () => {
+  if (window.scrollY > 200) {
+    backToTopBtn.style.display = "flex";
+  } else {
+    backToTopBtn.style.display = "none";
+  }
+});
+
+backToTopBtn.addEventListener("click", () => {
+  window.scrollTo({ top: 0, behavior: "smooth" });
+});
+
+openFormBtn.addEventListener("click", () => toggleModal(true));
+closeModalBtn.addEventListener("click", () => toggleModal(false));
+modal.addEventListener("click", event => {
+  if (event.target === modal) {
+    toggleModal(false);
+  }
+});
+
+document.addEventListener("keydown", event => {
+  if (event.key === "Escape" && modal.getAttribute("aria-hidden") === "false") {
+    toggleModal(false);
+  }
+});
+
+function toggleModal(open) {
+  modal.setAttribute("aria-hidden", open ? "false" : "true");
+  document.body.style.overflow = open ? "hidden" : "";
+  if (open) {
+    submissionForm.querySelector("input, textarea").focus();
+  } else {
+    submissionForm.reset();
+    resetErrors();
+    successMessage.hidden = true;
+  }
+}
+
+submissionForm.addEventListener("submit", event => {
+  event.preventDefault();
+  const isValid = validateForm();
+  if (isValid) {
+    successMessage.hidden = false;
+    submissionForm.reset();
+    setTimeout(() => {
+      toggleModal(false);
+    }, 1800);
+  }
+});
+
+submissionForm.addEventListener("reset", () => {
+  resetErrors();
+  successMessage.hidden = true;
+});
+
+function validateForm() {
+  resetErrors();
+  let valid = true;
+
+  const title = submissionForm.newsTitle.value.trim();
+  const link = submissionForm.newsLink.value.trim();
+  const source = submissionForm.newsSource.value.trim();
+  const summary = submissionForm.newsSummary.value.trim();
+  const email = submissionForm.email.value.trim();
+
+  if (!title) {
+    setError("titleError", "请填写标题");
+    valid = false;
+  }
+
+  const urlPattern = /^(https?:\/\/)[\w.-]+(?:\.[\w\.-]+)+(?:[\w\-\._~:\/?#\[\]@!$&'()*+,;=.]+)?$/;
+  if (!link || !urlPattern.test(link)) {
+    setError("linkError", "请输入有效的链接（需以http或https开头）");
+    valid = false;
+  }
+
+  if (!source) {
+    setError("sourceError", "请填写来源");
+    valid = false;
+  }
+
+  if (!summary) {
+    setError("summaryError", "请填写摘要");
+    valid = false;
+  }
+
+  const emailPattern = /^[\w.-]+@[\w.-]+\.[A-Za-z]{2,}$/;
+  if (!email || !emailPattern.test(email)) {
+    setError("emailError", "请输入有效的邮箱地址");
+    valid = false;
+  }
+
+  return valid;
+}
+
+function setError(id, message) {
+  const errorElement = document.getElementById(id);
+  errorElement.textContent = message;
+}
+
+function resetErrors() {
+  submissionForm.querySelectorAll(".error").forEach(el => (el.textContent = ""));
+}
+
+renderHotlist();
+filterButtons[0].classList.add("active");

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,500 @@
+:root {
+  --primary: #c92a2a;
+  --primary-light: #ff6b6b;
+  --background: #ffffff;
+  --surface: #f6f7fb;
+  --text: #1f1f1f;
+  --muted: #6b7280;
+  --shadow: 0 12px 30px rgba(201, 42, 42, 0.1);
+}
+
+body.dark-theme {
+  --background: #0f172a;
+  --surface: #1e293b;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --shadow: 0 12px 30px rgba(15, 23, 42, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Noto Sans SC", "Microsoft YaHei", sans-serif;
+  background: var(--background);
+  color: var(--text);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  border-radius: 12px;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background: linear-gradient(135deg, var(--primary), var(--primary-light));
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.search-form {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.2);
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  backdrop-filter: blur(8px);
+}
+
+.search-form input {
+  border: none;
+  background: transparent;
+  color: #fff;
+  outline: none;
+  min-width: 220px;
+}
+
+.search-form input::placeholder {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-form button {
+  border: none;
+  background: #fff;
+  color: var(--primary);
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease;
+}
+
+.search-form button:hover {
+  transform: translateY(-1px);
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.header-actions button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.header-actions button#themeToggle {
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+
+.primary-btn {
+  background: #fff;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.header-actions button:hover,
+.primary-btn:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  gap: 2rem;
+  padding: 2rem;
+}
+
+.hotlist {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: var(--shadow);
+}
+
+.section-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.section-header h1 {
+  margin: 0;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.controls select,
+.controls button {
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.controls select {
+  background: #fff;
+  color: var(--text);
+}
+
+.controls button {
+  background: var(--primary);
+  color: #fff;
+  transition: background 0.3s ease;
+}
+
+.controls button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.hotlist-items {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.hot-card {
+  position: relative;
+  background: #fff;
+  border-radius: 18px;
+  padding: 1.2rem;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+body.dark-theme .hot-card {
+  background: rgba(30, 41, 59, 0.85);
+}
+
+.hot-card:hover {
+  transform: translateY(-8px);
+  box-shadow: 0 24px 40px rgba(201, 42, 42, 0.2);
+}
+
+.hot-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.hot-card-rank {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.hot-card-icon {
+  font-size: 1.2rem;
+}
+
+.hot-card-content h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.hot-card-content p {
+  margin: 0.4rem 0 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.hot-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.hot-card img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+}
+
+.sidebar {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 90px;
+  height: fit-content;
+}
+
+.word-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: rgba(201, 42, 42, 0.12);
+  color: var(--primary);
+  padding: 0.4rem 1rem;
+  transition: transform 0.2s ease;
+}
+
+.tag-large { font-size: 1.1rem; }
+.tag-medium { font-size: 1rem; }
+.tag-small { font-size: 0.9rem; }
+
+.tag:hover {
+  transform: translateY(-3px);
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-btn {
+  border: 1px solid var(--primary);
+  color: var(--primary);
+  background: transparent;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.filter-btn.active,
+.filter-btn:hover {
+  background: var(--primary);
+  color: #fff;
+}
+
+.back-to-top {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  border-radius: 999px;
+  width: 48px;
+  height: 48px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(201, 42, 42, 0.35);
+  transition: transform 0.2s ease;
+}
+
+.back-to-top:hover {
+  transform: translateY(-4px);
+}
+
+.site-footer {
+  padding: 1.5rem 2rem;
+  background: var(--surface);
+  text-align: center;
+  color: var(--muted);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.65);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 20;
+}
+
+.modal[aria-hidden="false"] {
+  display: flex;
+}
+
+.modal-content {
+  background: var(--background);
+  color: var(--text);
+  border-radius: 24px;
+  padding: 2rem;
+  width: min(520px, 100%);
+  position: relative;
+  box-shadow: var(--shadow);
+  animation: slideUp 0.4s ease;
+}
+
+.modal-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--muted);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.form-group input,
+.form-group textarea {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 0.65rem 0.9rem;
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text);
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+}
+
+.form-actions button[type="reset"] {
+  border: 1px solid var(--primary);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--primary);
+  padding: 0.5rem 1.2rem;
+  cursor: pointer;
+}
+
+.error {
+  color: #ef4444;
+  font-size: 0.85rem;
+}
+
+.form-success {
+  margin-top: 1rem;
+  color: #059669;
+  background: rgba(16, 185, 129, 0.12);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 1024px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    order: -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .search-form {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .search-form input {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .layout {
+    padding: 1.5rem;
+  }
+
+  .hot-card img {
+    height: 140px;
+  }
+}
+
+@media (max-width: 480px) {
+  .layout {
+    padding: 1rem;
+  }
+
+  .hot-card {
+    padding: 1rem;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .site-header {
+    padding: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive Chinese news hotlist landing page with SEO metadata, header search, and interactive hotlist controls
- style the layout with card-based presentation, sidebar filters, dark/light theme support, and responsive adjustments
- implement client-side interactivity for sorting, pagination, back-to-top button, and a validated submission modal form

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e6259bec08832786c6e30f08c5b167